### PR TITLE
add mbox, mmu and hotplug tests

### DIFF
--- a/test/pytest/test_hotplug.py
+++ b/test/pytest/test_hotplug.py
@@ -3,16 +3,15 @@ import pytest
 from pexpect.fdpexpect import fdspawn
 
 @pytest.mark.timeout(400)
-
-def test_hotplug(qemu_instance_per_fcn):
-    qemu_instance_per_fcn['serial2'].sendline('root')
+@pytest.mark.parametrize('core_num', range(1,8))
+def test_hotplug(qemu_instance_per_mdl, core_num):
+    qemu_instance_per_mdl['serial2'].sendline('root')
     cpu_path = '/sys/devices/system/cpu/'
 
-    for i in range(1,8):
-        qemu_instance_per_fcn['serial2'].sendline('echo 0 > ' + cpu_path + 'cpu' + str(i) + '/online') #turn CPU i off
-        qemu_instance_per_fcn['serial2'].sendline('more ' + cpu_path + 'offline')
-        assert(qemu_instance_per_fcn['serial2'].expect(str(i)) == 0)
+    qemu_instance_per_mdl['serial2'].sendline('echo 0 > ' + cpu_path + 'cpu' + str(core_num) + '/online') #turn CPU core_num off
+    qemu_instance_per_mdl['serial2'].sendline('more ' + cpu_path + 'offline')
+    assert(qemu_instance_per_mdl['serial2'].expect(str(core_num)) == 0)
 
-        qemu_instance_per_fcn['serial2'].sendline('echo 1 > ' + cpu_path + 'cpu' + str(i) + '/online') #turn CPU i on
-        qemu_instance_per_fcn['serial2'].sendline('more ' + cpu_path + 'online')
-        assert(qemu_instance_per_fcn['serial2'].expect('0-7') == 0)
+    qemu_instance_per_mdl['serial2'].sendline('echo 1 > ' + cpu_path + 'cpu' + str(core_num) + '/online') #turn CPU core_num on
+    qemu_instance_per_mdl['serial2'].sendline('more ' + cpu_path + 'online')
+    assert(qemu_instance_per_mdl['serial2'].expect('0-7') == 0)

--- a/test/pytest/test_hotplug.py
+++ b/test/pytest/test_hotplug.py
@@ -1,0 +1,18 @@
+import serial
+import pytest
+from pexpect.fdpexpect import fdspawn
+
+@pytest.mark.timeout(400)
+
+def test_hotplug(qemu_instance_per_fcn):
+    qemu_instance_per_fcn['serial2'].sendline('root')
+    cpu_path = '/sys/devices/system/cpu/'
+
+    for i in range(1,8):
+        qemu_instance_per_fcn['serial2'].sendline('echo 0 > ' + cpu_path + 'cpu' + str(i) + '/online') #turn CPU i off
+        qemu_instance_per_fcn['serial2'].sendline('more ' + cpu_path + 'offline')
+        assert(qemu_instance_per_fcn['serial2'].expect(str(i)) == 0)
+
+        qemu_instance_per_fcn['serial2'].sendline('echo 1 > ' + cpu_path + 'cpu' + str(i) + '/online') #turn CPU i on
+        qemu_instance_per_fcn['serial2'].sendline('more ' + cpu_path + 'online')
+        assert(qemu_instance_per_fcn['serial2'].expect('0-7') == 0)

--- a/test/pytest/test_mbox_multi_system.py
+++ b/test/pytest/test_mbox_multi_system.py
@@ -5,18 +5,16 @@ from pexpect.fdpexpect import fdspawn
 
 @pytest.mark.timeout(400)
 @pytest.mark.parametrize('core_num', range(8))
-
-def test_rtps_hpps(qemu_instance_per_fcn, host, core_num):
-    hostname = 'hpscqemu'
+def test_rtps_hpps(qemu_instance_per_mdl, host, core_num):
     tester_remote_path = '/opt/hpsc-utils/mbox-server-tester'
     
-    qemu_instance_per_fcn['serial1'].sendline('test_mbox_rtps_hpps 3 4')
-    assert(qemu_instance_per_fcn['serial1'].expect('TEST: test_mbox_rtps_hpps: begin') == 0)
+    qemu_instance_per_mdl['serial1'].sendline('test_mbox_rtps_hpps 3 4')
+    assert(qemu_instance_per_mdl['serial1'].expect('TEST: test_mbox_rtps_hpps: begin') == 0)
 
-    out = subprocess.run(['ssh', hostname] + [tester_remote_path] + ['-c', str(core_num)], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out = subprocess.run(['ssh', host] + [tester_remote_path] + ['-c', str(core_num)], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    assert(qemu_instance_per_fcn['serial1'].expect('TEST_LINK: request: ACK received') == 0)
-    assert(qemu_instance_per_fcn['serial1'].expect('TEST_LINK: request: reply received') == 0)
-    assert(qemu_instance_per_fcn['serial1'].expect('TEST: test_mbox_rtps_hpps: success') == 0)
+    assert(qemu_instance_per_mdl['serial1'].expect('TEST_LINK: request: ACK received') == 0)
+    assert(qemu_instance_per_mdl['serial1'].expect('TEST_LINK: request: reply received') == 0)
+    assert(qemu_instance_per_mdl['serial1'].expect('TEST: test_mbox_rtps_hpps: success') == 0)
 
     assert out.returncode == 64 #hpps returns number of bytes sent. we expect 64 bytes

--- a/test/pytest/test_mbox_multi_system.py
+++ b/test/pytest/test_mbox_multi_system.py
@@ -1,0 +1,22 @@
+import serial
+import subprocess
+import pytest
+from pexpect.fdpexpect import fdspawn
+
+@pytest.mark.timeout(400)
+@pytest.mark.parametrize('core_num', range(8))
+
+def test_rtps_hpps(qemu_instance_per_fcn, host, core_num):
+    hostname = 'hpscqemu'
+    tester_remote_path = '/opt/hpsc-utils/mbox-server-tester'
+    
+    qemu_instance_per_fcn['serial1'].sendline('test_mbox_rtps_hpps 3 4')
+    assert(qemu_instance_per_fcn['serial1'].expect('TEST: test_mbox_rtps_hpps: begin') == 0)
+
+    out = subprocess.run(['ssh', hostname] + [tester_remote_path] + ['-c', str(core_num)], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    assert(qemu_instance_per_fcn['serial1'].expect('TEST_LINK: request: ACK received') == 0)
+    assert(qemu_instance_per_fcn['serial1'].expect('TEST_LINK: request: reply received') == 0)
+    assert(qemu_instance_per_fcn['serial1'].expect('TEST: test_mbox_rtps_hpps: success') == 0)
+
+    assert out.returncode == 64 #hpps returns number of bytes sent. we expect 64 bytes

--- a/test/pytest/test_mmu.py
+++ b/test/pytest/test_mmu.py
@@ -1,0 +1,9 @@
+import serial
+import pytest
+from pexpect.fdpexpect import fdspawn
+
+@pytest.mark.timeout(400)
+def test_trch_mmu(qemu_instance_per_fcn):
+    assert(qemu_instance_per_fcn['serial0'].expect('MMU map-write-read test success') == 0)
+    assert(qemu_instance_per_fcn['serial0'].expect('MMU write-map-read test success') == 0)
+    assert(qemu_instance_per_fcn['serial0'].expect('MMU mapping swap test success') == 0)


### PR DESCRIPTION
MMU tests do not work with current conftest.py yet since TRCH serial port initialization is commented out.